### PR TITLE
Added `CODECOV_TOKEN` for private repos

### DIFF
--- a/lib/sendToCodeCov.io.js
+++ b/lib/sendToCodeCov.io.js
@@ -20,6 +20,9 @@ var sendToCodecov = function(str, cb){
   if (!!configuration.pullRequest){
     query.pull_request = configuration.pullRequest;
   }
+  if (!!process.env.token){
+    query.token = process.env.codecov_token;
+  }
 
   var url = urlgrey('https://codecov.io/upload/v1').query(query).toString();
 


### PR DESCRIPTION
> In reference to #4 

For private repositories we need to accept an upload token. For consistency use `CODECOV_TOKEN`.
