### PR TITLE
docs: update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,19 @@ This library currently supports the following CI companies: [Travis CI](https://
 **With Mocha:**
 
 ```sh
-istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec && cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js
+istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec && cat ./coverage/coverage.json | ./node_modules/.bin/codecov
 ```
 
 **With Jasmine:**
 
 ```sh
-istanbul cover jasmine-node --captureExceptions spec/ && cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js
+istanbul cover jasmine-node --captureExceptions spec/ && cat ./coverage/coverage.json | ./node_modules/.bin/codecov
+```
+
+**With Tape:**
+
+```sh
+istanbul cover test.js && cat ./coverage/coverage.json | ./node_modules/.bin/codecov
 ```
 
 [travis-image]: https://travis-ci.org/cainus/codecov.io.svg?branch=master


### PR DESCRIPTION
I hope this is useful. Haven't quite gotten [covert](https://github.com/substack/covert) or [coverify](https://github.com/substack/coverify) working with tape (for a true unixy experience), so decided to stick to the existing istanbul example. Thanks!
### Changes
- __docs__: Shortens existing examples by leveraging `node_modules/.bin`.
- __docs__: Adds [tape](https://github.com/substack/tape) example.