### PR TITLE
lib: cleanup sendToCodeCov

### DIFF
--- a/lib/sendToCodeCov.io.js
+++ b/lib/sendToCodeCov.io.js
@@ -7,9 +7,7 @@ var getConfiguration = require('./getConfiguration');
 // curl -X POST -H 'Content-Type: text/lcov' -d 'SF:money.py\nFN:11,(anonymous_1)\nDA:1,1\nDA:2,1\nDA:11,1\nend_of_record' https://codecov.io/upload/v1?token=473c8c5b-10ee-4d83-86c6-bfd72a185a27&commit=743b04806ea677403aa2ff26c6bdeb85005de658&branch=master
 
 var sendToCodecov = function(str, cb){
-  var withTestTokenUrl = 'https://codecov.io/upload/v1?token=473c8c5b-10ee-4d83-86c6-bfd72a185a27&commit=743b04806ea677403aa2ff26c6bdeb85005de658&branch=master';
   var query = getConfiguration();
-  console.log("configuration: ", query);
   var token = (process.env.codecov_token || process.env.CODECOV_TOKEN);
   if (token){
     query.token = token;


### PR DESCRIPTION
Don't print configuration as it could contain privileged information.

Also removes unused variable.

As of https://github.com/isaacs/node-tap/pull/180, this can be used in tap the same way coveralls can be. It would be nice to not print the configuration as it contains the repo token and possibly other identifying information.
