### PR TITLE
Fixes #33, node tap and other dependencies, including lots of grunt modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov.io",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "lcov posting to codecov.io",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/cainus/codecov.io",
   "dependencies": {
-    "request": "2.69.1",
+    "request": "2.72.0",
     "urlgrey": "0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I can't run tests locally because it tries to get your service.

I assume there is no issue in bumping the version. Please push a new version to npm soon.

It is super hard to fix by pinning a very old version of grunt tools.
