### PR TITLE
Update requests to 2.74.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/cainus/codecov.io",
   "dependencies": {
-    "request": "2.69.1",
+    "request": "2.74.0",
     "urlgrey": "0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`tough-cookie` contains a vulnerability. `request` depend on `tough-cookie`, so we need `request` => 2.74.0 to get the fix. See https://nodesecurity.io/advisories/130.

It would be really good to merge this and release as soon as you can. Thanks.
