### PR TITLE
bump dep request to v2.83.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/cainus/codecov.io",
   "dependencies": {
-    "request": "2.69.1",
+    "request": "2.83.0",
     "urlgrey": "0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
[Snyk test: request@2.83.0](https://snyk.io/test/npm/request/2.83.0?severity=high&severity=medium&severity=low)

fixes #39